### PR TITLE
Custom PHP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ web1.somedc.prod         ansible_ssh_host=10.0.1.111
 php_fpm_user = apache
 php_fpm_group = apache
 
-# What PHP version to use. Available: 5.4, 5.5 and 5.6. Default: 5.4.
+# What PHP version to use. Available: 5.4, 5.5 and 5.6. Default: 5.6.
 php_version = 5.4
 
 # What folder to use to store sessions. Default: /tmp
@@ -29,6 +29,15 @@ php_sessions_dir = /tmp
 
 *Note:* If you want to change the PHP version on an already provisioned server,
 you must first uninstall manually the previous version.
+
+Also available is the `php_custom_extensions` variable, it is an array of extensions
+and as such should be set in a ansible vars file as yaml. eg:
+
+```yaml
+php_custom_extensions:
+- mcrypt
+- opcache
+```
 
 See also
 ---------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 php_version: 5.4
 
+php_custom_extensions: []
 php_fpm_user: apache
 php_fpm_group: apache
 php_sessions_dir: "/tmp"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-php_version: 5.4
+php_version: 5.6
 
 php_custom_extensions: []
 php_fpm_user: apache

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -18,6 +18,18 @@
     - php
     - pkgs
 
+- name: "Install custom PHP extensions"
+  yum: >
+    name="{{ php_custom_extensions|map('replace','',('php%s' % php_version).replace('.','') + '-php-', 1)|join(',') }}"
+    state=latest
+    enablerepo=epel,remi
+  when: php_custom_extensions|length > 0
+  notify:
+    - Restart php-fpm
+  tags:
+    - php
+    - pkgs
+
 - name: "Set php facts"
   set_fact:
     php_fpm_service: php{{ php_version | replace('.','') }}-php-fpm

--- a/tests/tests_custom_ext.yml
+++ b/tests/tests_custom_ext.yml
@@ -1,12 +1,15 @@
 ---
 # File for ansible-role-test (https://github.com/aeriscloud/ansible-role-test)
-name: "5.6 installation"
+name: "Custom Extensions"
 playbook:
 - hosts: centos
   sudo: yes
   roles:
   - role: "@ROLE_NAME@"
     php_version: 5.6
+    php_custom_extensions:
+    - mcrypt
+    - opcache
   post_tasks:
   - stat: path=/usr/bin/php
     register: php_binary

--- a/tests/tests_php54.yml
+++ b/tests/tests_php54.yml
@@ -1,6 +1,6 @@
 ---
 # File for ansible-role-test (https://github.com/aeriscloud/ansible-role-test)
-name: "Tests"
+name: "5.4 installation"
 playbook:
 - hosts: centos
   sudo: yes

--- a/tests/tests_php55.yml
+++ b/tests/tests_php55.yml
@@ -1,6 +1,6 @@
 ---
 # File for ansible-role-test (https://github.com/aeriscloud/ansible-role-test)
-name: "Tests"
+name: "5.5 installation"
 playbook:
 - hosts: centos
   sudo: yes


### PR DESCRIPTION
Allows for the installation of custom PHP extensions, should be defined in the group_var/vars files as it is an array.
